### PR TITLE
Send coverage to Code Climate only on Travis build

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,9 +4,11 @@ SimpleCov.start
 
 require 'fasterer'
 require 'pry'
-require 'codeclimate-test-reporter'
 
-CodeClimate::TestReporter.start
+if ENV['TRAVIS']
+  require 'codeclimate-test-reporter'
+  CodeClimate::TestReporter.start
+end
 
 def RSpec.root
   @root_path = Pathname.new(File.dirname(__FILE__))


### PR DESCRIPTION
Without this, local test outputs following message:
```
I, [2015-08-06T05:31:38.666080 #15419]  INFO -- : Not reporting to Code Climate because ENV['CODECLIMATE_REPO_TOKEN'] is not set.
```