### PR TITLE
Handle empty config file

### DIFF
--- a/lib/fasterer/file_traverser.rb
+++ b/lib/fasterer/file_traverser.rb
@@ -36,8 +36,13 @@ module Fasterer
     end
 
     def config_file
-      @config_file ||= if File.exists?(CONFIG_FILE_NAME)
-        YAML.load_file(CONFIG_FILE_NAME)
+      @config_file ||= if File.exist?(CONFIG_FILE_NAME)
+        loaded = YAML.load_file(CONFIG_FILE_NAME)
+        if loaded
+          loaded.merge!(nil_config_file) { |_k, v1, v2| v1 || v2 }
+        else
+          nil_config_file
+        end
       else
         nil_config_file
       end

--- a/spec/lib/fasterer/file_traverser_spec.rb
+++ b/spec/lib/fasterer/file_traverser_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Fasterer::FileTraverser do
+  include FileHelper
+  include_context 'isolated environment'
+
+  describe 'config_file' do
+    context 'with no config file' do
+      let(:file_traverser) { Fasterer::FileTraverser.new('.') }
+
+      it 'returns nil_config_file' do
+        expect(file_traverser.config_file)
+          .to eq(file_traverser.send(:nil_config_file))
+      end
+    end
+
+    context 'with empty config file' do
+      before(:each) do
+        create_file(Fasterer::FileTraverser::CONFIG_FILE_NAME, '')
+      end
+
+      let(:file_traverser) { Fasterer::FileTraverser.new('.') }
+
+      it 'returns nil_config_file' do
+        expect(file_traverser.config_file)
+          .to eq(file_traverser.send(:nil_config_file))
+      end
+    end
+
+    context 'with empty values' do
+      before(:each) do
+        create_file(Fasterer::FileTraverser::CONFIG_FILE_NAME,
+                    ['speedups:',
+                     '',
+                     'exclude_paths:'])
+      end
+
+      let(:file_traverser) { Fasterer::FileTraverser.new('.') }
+
+      it 'returns nil_config_file' do
+        expect(file_traverser.config_file)
+          .to eq(file_traverser.send(:nil_config_file))
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,9 @@ require 'simplecov'
 SimpleCov.start
 
 require 'fasterer'
+require 'fasterer/cli'
 require 'pry'
+Dir["#{File.dirname(__FILE__)}/support/*.rb"].each { |f| require f }
 
 if ENV['TRAVIS']
   require 'codeclimate-test-reporter'

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -1,0 +1,33 @@
+require 'fileutils'
+
+# Util methods for processing file.
+module FileHelper
+  # Create file with at given path with given content. Ensure parent directories
+  # exist.
+  #
+  # path    - An String path of file.
+  # content - An String or an Array of Strings content of file.
+  def create_file(path, content)
+    file_path = File.expand_path(path)
+    dir_path = File.dirname(file_path)
+    FileUtils.makedirs(dir_path) unless File.exist?(dir_path)
+    write_file(path, content)
+  end
+
+  # Write file content at given path.
+  #
+  # path    - An String path of file.
+  # content - An String or an Array of Strings content of file.
+  def write_file(path, content)
+    File.open(path, 'w') do |file|
+      case content
+      when ''
+        # Create empty file.
+      when String
+        file.puts content
+      when Array
+        file.puts content.join("\n")
+      end
+    end
+  end
+end

--- a/spec/support/isolated_environment.rb
+++ b/spec/support/isolated_environment.rb
@@ -1,0 +1,12 @@
+require 'tmpdir'
+
+shared_context 'isolated environment' do
+  around do |example|
+    Dir.mktmpdir do |tmpdir|
+      tmpdir = File.realpath(tmpdir)
+      Dir.chdir(tmpdir) do
+        example.run
+      end
+    end
+  end
+end


### PR DESCRIPTION
Use `nil_config_file` for following environment:

- No `.fasterer.yml`
- Empty `.fasterer.yml`

Use default value `{}`, `[]` for `speedups`, `exclude_paths` respectively, for this kind of `.fasterer.yml`:
``` yaml
speedups:

exclude_paths:
```