### PR TITLE
Filter `spec` directory for coverage

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 require 'bundler/setup'
 require 'simplecov'
-SimpleCov.start
+SimpleCov.start do
+  add_filter '/spec/'
+  add_filter '/vendor/'
+end
 
 require 'fasterer'
 require 'pry'


### PR DESCRIPTION
When you run `rake` on project root, `coverage/index.html` contains files under `spec/lib` directory.