### PR TITLE
Abort if the file traverser found an offense

### DIFF
--- a/lib/fasterer/cli.rb
+++ b/lib/fasterer/cli.rb
@@ -5,6 +5,7 @@ module Fasterer
     def self.execute
       file_traverser = Fasterer::FileTraverser.new('.')
       file_traverser.traverse
+      abort if file_traverser.offenses_found?
     end
   end
 end

--- a/lib/fasterer/file_traverser.rb
+++ b/lib/fasterer/file_traverser.rb
@@ -43,9 +43,14 @@ module Fasterer
       end
     end
 
+    def offenses_found?
+      !!offenses_found
+    end
+
     private
 
     attr_reader :parse_error_paths
+    attr_accessor :offenses_found
 
     def nil_config_file
       { SPEEDUPS_KEY => {}, EXCLUDE_PATHS_KEY => [] }
@@ -57,7 +62,10 @@ module Fasterer
     rescue RubyParser::SyntaxError, Racc::ParseError, Timeout::Error
       parse_error_paths.push(path)
     else
-      output(analyzer) if offenses_grouped_by_type(analyzer).any?
+      if offenses_grouped_by_type(analyzer).any?
+        output(analyzer)
+        self.offenses_found = true
+      end
     end
 
     def scannable_files


### PR DESCRIPTION
By exiting the application with a nonzero status when an offense is found, fasterer can be integrated into continuous integration to prevent slow code from being committed.

I didn't see any specs that cover the file traverser or CLI code, so I didn't add any. If this is incorrect let me know and I can try to add specs for this change as well.

Let me know what I can do to get this merged if you agree it belongs in fasterer.

Thanks!