### PR TITLE
Allow a directory or individual file to be passed in

### DIFF
--- a/bin/fasterer
+++ b/bin/fasterer
@@ -2,4 +2,4 @@
 $LOAD_PATH << File.expand_path('../../lib', __FILE__)
 require 'fasterer/cli'
 
-Fasterer::CLI.execute
+Fasterer::CLI.execute ARGV[0]

--- a/lib/fasterer/cli.rb
+++ b/lib/fasterer/cli.rb
@@ -2,8 +2,8 @@ require_relative 'file_traverser'
 
 module Fasterer
   class CLI
-    def self.execute
-      file_traverser = Fasterer::FileTraverser.new('.')
+    def self.execute(start_path ='.')
+      file_traverser = Fasterer::FileTraverser.new(start_path)
       file_traverser.traverse
     end
   end

--- a/lib/fasterer/file_traverser.rb
+++ b/lib/fasterer/file_traverser.rb
@@ -66,7 +66,7 @@ module Fasterer
 
     def all_files
       Dir["#{@path}/**/*.rb"].map do |ruby_file_path|
-        Pathname(ruby_file_path).relative_path_from(@path).to_s
+        Pathname(ruby_file_path).to_s
       end
     end
 


### PR DESCRIPTION
Related to Ticket #12 
Allow a directory or file to be passed as an argument to the fasterer binary/CLI

Confirmed these changes allow
1. no args 
   fasterer
2. a completely different directory (eg. an older ruby project)
   fastener 'path/to/ruby/1.8/project'
3. an individual file
  fastener 'my/current/bad_file.rb'

All current tests pass, but this needs more tests. (I couldn't quite determine where was the best place to put tests for the CLI/args logic)