### PR TITLE
Don't require pry in file_traverser.rb

### DIFF
--- a/lib/fasterer/file_traverser.rb
+++ b/lib/fasterer/file_traverser.rb
@@ -1,7 +1,6 @@
 require 'pathname'
 require 'colorize'
 require 'English'
-require 'pry'
 
 require_relative 'analyzer'
 require_relative 'config'


### PR DESCRIPTION
I guess this was unintentionally committed in https://github.com/DamirSvrtan/fasterer/commit/cad0a0ef3e5a1216a9addb0cf79bedb62cfb803a.