### PR TITLE
Fix "occured" typo in README + tweak formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,22 +30,21 @@ fasterer
 
 ## Example output
 
-```shell
-
+```
 app/models/post.rb
-Array#select.first is slower than Array#detect. Occured at lines: 57, 61.
+Array#select.first is slower than Array#detect. Occurred at lines: 57, 61.
 
 db/seeds/cities.rb
-Hash#keys.each is slower than Hash#each_key. Occured at lines: 15, 33.
+Hash#keys.each is slower than Hash#each_key. Occurred at lines: 15, 33.
 
 test/options_test.rb
-Hash#merge! with one argument is slower than Hash#[]. Occured at lines: 84.
+Hash#merge! with one argument is slower than Hash#[]. Occurred at lines: 84.
 
 test/module_test.rb
-Don't rescue NoMethodError, rather check with respond_to?. Occured at lines: 272.
+Don't rescue NoMethodError, rather check with respond_to?. Occurred at lines: 272.
 
 spec/cache/mem_cache_store_spec.rb
-Use tr instead of gsub when grepping plain strings. Occured at lines: 161.
+Use tr instead of gsub when grepping plain strings. Occurred at lines: 161.
 ```
 ## Configuration
 


### PR DESCRIPTION
Hey @DamirSvrtan - thanks for the gem!

This PR is trivial - it fixes a typo in the README (which was fixed in the actual code in https://github.com/DamirSvrtan/fasterer/pull/10) and no longer marks the example output as shell code to avoid the odd coloring that occurs part way through this section:

<img width="787" alt="screenshot 2016-11-14 15 54 58" src="https://cloud.githubusercontent.com/assets/22621/20282459/bb1d490a-aa82-11e6-86fa-3810471c5248.png">
