### PR TITLE
Ignore constants when checking for fetch with single argument

### DIFF
--- a/lib/fasterer/method_call.rb
+++ b/lib/fasterer/method_call.rb
@@ -115,6 +115,10 @@ module Fasterer
     def value
       @value ||= @element[1]
     end
+
+    def constant?
+      value.frozen?
+    end
   end
 
   class Primitive

--- a/lib/fasterer/scanners/method_call_scanner.rb
+++ b/lib/fasterer/scanners/method_call_scanner.rb
@@ -114,7 +114,9 @@ module Fasterer
     end
 
     def check_fetch_offense
-      if method_call.arguments.count == 2 && !method_call.has_block?
+      if method_call.arguments.count == 2 &&
+          !method_call.has_block? &&
+          !method_call.arguments[1].constant?
         add_offense(:fetch_with_argument_vs_block)
       end
     end

--- a/spec/support/analyzer/14_fetch_with_argument_vs_block.rb
+++ b/spec/support/analyzer/14_fetch_with_argument_vs_block.rb
@@ -8,4 +8,20 @@ def fast
   HASH.fetch(:writing) { [*1..100] }
 end
 
+def fast_with_symbol
+  HASH.fetch(:writing, :fast)
+end
+
+def fast_with_boolean
+  HASH.fetch(:writing, true)
+end
+
+def fast_with_nil
+  HASH.fetch(:writing, true)
+end
+
+def fast_with_const
+  HASH.fetch(:writing, HASH)
+end
+
 HASH.fetch(:writing)


### PR DESCRIPTION
Per https://github.com/JuanitoFatas/fast-ruby/blob/master/code/hash/fetch-vs-fetch-with-block.rb,
it is faster to use the argument method if the argument is a constant
aka does not allocate an object.