### PR TITLE
Fix check_symbol_to_proc crash

### DIFF
--- a/lib/fasterer/scanners/method_call_scanner.rb
+++ b/lib/fasterer/scanners/method_call_scanner.rb
@@ -130,6 +130,7 @@ module Fasterer
 
       return unless body_method_call.arguments.count.zero?
       return if body_method_call.has_block?
+      return if body_method_call.receiver.nil?
       return unless body_method_call.receiver.name == method_call.block_argument_names.first
 
       add_offense(:block_vs_symbol_to_proc)

--- a/spec/lib/fasterer/analyzer/18_block_vs_symbol_to_proc_spec.rb
+++ b/spec/lib/fasterer/analyzer/18_block_vs_symbol_to_proc_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Fasterer::Analyzer do
   let(:test_file_path) { RSpec.root.join('support', 'analyzer', '18_block_vs_symbol_to_proc.rb') }
 
-  it 'should block that could be called with symbol 6 times' do
+  it 'should block that could be called with symbol 7 times' do
     analyzer = Fasterer::Analyzer.new(test_file_path)
     analyzer.scan
-    expect(analyzer.errors[:block_vs_symbol_to_proc].count).to eq(6)
+    expect(analyzer.errors[:block_vs_symbol_to_proc].count).to eq(7)
   end
 end

--- a/spec/support/analyzer/18_block_vs_symbol_to_proc.rb
+++ b/spec/support/analyzer/18_block_vs_symbol_to_proc.rb
@@ -34,3 +34,6 @@ numbers.each { |number| number.to_s }
 numbers.map { |number| number.to_s }
 numbers.any? { |number| number.even? }
 numbers.find { |number| number.even? }
+
+instance_eval { |_| method_call_without_receiver }
+instance_eval { |object| object.to_s }


### PR DESCRIPTION
`check_symbol_to_proc` crashes when block contains a method call without a receiver.

I added the test case below,

```ruby
instance_eval { |_| method_call_without_receiver }
```

and it produced the following error.

```
     Failure/Error: return unless body_method_call.receiver.name == method_call.block_argument_names.first

     NoMethodError:
       undefined method `name' for nil:NilClass
     # ./lib/fasterer/scanners/method_call_scanner.rb:133:in `check_symbol_to_proc'
     # ./lib/fasterer/scanners/method_call_scanner.rb:48:in `check_offense'
     # ./lib/fasterer/scanners/method_call_scanner.rb:13:in `initialize'
     # ./lib/fasterer/analyzer.rb:71:in `new'
     # ./lib/fasterer/analyzer.rb:71:in `scan_method_calls'
     # ./lib/fasterer/analyzer.rb:54:in `scan_by_token'
     # ./lib/fasterer/analyzer.rb:36:in `traverse_sexp_tree'
     # ./lib/fasterer/analyzer.rb:45:in `block in traverse_sexp_tree'
     # ./lib/fasterer/analyzer.rb:45:in `each'
     # ./lib/fasterer/analyzer.rb:45:in `traverse_sexp_tree'
     # ./lib/fasterer/analyzer.rb:22:in `scan'
     # ./spec/lib/fasterer/analyzer/18_block_vs_symbol_to_proc_spec.rb:8:in `block (2 levels) in <top (required)>'
```