### PR TITLE
Fix check_symbol_to_proc false positives on lambda literals

### DIFF
--- a/lib/fasterer/method_call.rb
+++ b/lib/fasterer/method_call.rb
@@ -32,6 +32,10 @@ module Fasterer
       call_element[3..-1] || []
     end
 
+    def lambda_literal?
+      call_element.sexp_type == :lambda
+    end
+
     private
 
     attr_reader :call_element

--- a/lib/fasterer/scanners/method_call_scanner.rb
+++ b/lib/fasterer/scanners/method_call_scanner.rb
@@ -125,6 +125,7 @@ module Fasterer
       return if method_call.block_body.nil?
       return unless method_call.block_body.sexp_type == :call
       return if method_call.arguments.count > 0
+      return if method_call.lambda_literal?
 
       body_method_call = MethodCall.new(method_call.block_body)
 

--- a/spec/lib/fasterer/analyzer/18_block_vs_symbol_to_proc_spec.rb
+++ b/spec/lib/fasterer/analyzer/18_block_vs_symbol_to_proc_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Fasterer::Analyzer do
   let(:test_file_path) { RSpec.root.join('support', 'analyzer', '18_block_vs_symbol_to_proc.rb') }
 
-  it 'should block that could be called with symbol 7 times' do
+  it 'should block that could be called with symbol 9 times' do
     analyzer = Fasterer::Analyzer.new(test_file_path)
     analyzer.scan
-    expect(analyzer.errors[:block_vs_symbol_to_proc].count).to eq(7)
+    expect(analyzer.errors[:block_vs_symbol_to_proc].count).to eq(9)
   end
 end

--- a/spec/lib/fasterer/method_call_spec.rb
+++ b/spec/lib/fasterer/method_call_spec.rb
@@ -437,4 +437,36 @@ describe Fasterer::MethodCall do
       # expect(method_call.receiver.name).to eq('hi')
     end
   end
+
+  describe '#lambda_literal?' do
+    describe 'lambda literal without arguments' do
+      let(:code) { '-> {}' }
+
+      let(:call_element) { ripper }
+
+      it 'should be true' do
+        expect(method_call).to be_lambda_literal
+      end
+    end
+
+    describe 'lambda literal with an argument' do
+      let(:code) { '->(_) {}' }
+
+      let(:call_element) { ripper }
+
+      it 'should be true' do
+        expect(method_call).to be_lambda_literal
+      end
+    end
+
+    describe 'lambda method' do
+      let(:code) { 'lambda {}' }
+
+      let(:call_element) { ripper }
+
+      it 'should be false' do
+        expect(method_call).not_to be_lambda_literal
+      end
+    end
+  end
 end

--- a/spec/support/analyzer/18_block_vs_symbol_to_proc.rb
+++ b/spec/support/analyzer/18_block_vs_symbol_to_proc.rb
@@ -37,3 +37,7 @@ numbers.find { |number| number.even? }
 
 instance_eval { |_| method_call_without_receiver }
 instance_eval { |object| object.to_s }
+
+proc { |rule| rule.should_use_symbol }
+lambda { |rule| rule.should_use_symbol }
+->(obj) { obj.cannot_use_symbol }


### PR DESCRIPTION
Currently lambda literal like `->(x) { x.to_s }` violates the `check_symbol_to_proc` rule.

This rule makes sense when it is applied to method calls with blocks, but I'm not sure if the violation on lambda literal is an intentional behavior.

It feels awkward to me if I have to write `f = :to_s.to_proc` instead of `f = ->(x) { x.to_s }`.
