### PR TITLE
Don't consider unary method calls for to_proc

### DIFF
--- a/lib/fasterer/scanners/method_call_scanner.rb
+++ b/lib/fasterer/scanners/method_call_scanner.rb
@@ -119,6 +119,8 @@ module Fasterer
       end
     end
 
+    UNARY_METHODS = %i[+@ -@ ! ~].freeze
+
     # Need to refactor, fukken complicated conditions.
     def check_symbol_to_proc
       return unless method_call.block_argument_names.count == 1
@@ -128,6 +130,7 @@ module Fasterer
 
       body_method_call = MethodCall.new(method_call.block_body)
 
+      return if UNARY_METHODS.include?(body_method_call.name)
       return unless body_method_call.arguments.count.zero?
       return if body_method_call.has_block?
       return if body_method_call.receiver.nil?

--- a/spec/support/analyzer/18_block_vs_symbol_to_proc.rb
+++ b/spec/support/analyzer/18_block_vs_symbol_to_proc.rb
@@ -37,3 +37,8 @@ numbers.find { |number| number.even? }
 
 instance_eval { |_| method_call_without_receiver }
 instance_eval { |object| object.to_s }
+
+['foo'].map { |string| +string }
+['foo'].map { |string| -string }
+[true].map { |boolean| !boolean }
+[1, 2, 3].map { |number| ~number }


### PR DESCRIPTION
When considering a code block like

```
["foo"].map { |string| +string }
```

it should not be considered possible to convert the segment into a proc using the `Symbol#to_proc` method since it's a unary method call.

After looking, I couldn't find a way to determine if it was a unary call from `ruby_parser`, so I just hardcoded the list of unary methods in here.