### PR TITLE
Lock ruby parser to 3.13.0

### DIFF
--- a/fasterer.gemspec
+++ b/fasterer.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'colorize', '~> 0.7'
-  spec.add_dependency 'ruby_parser', '>= 3.13.0'
+  spec.add_dependency 'ruby_parser', '3.13.0'
 
   spec.add_development_dependency 'bundler', '>= 1.6'
   spec.add_development_dependency 'rake',    '~> 10.0'


### PR DESCRIPTION
Let's see if locking the Ruby parser will fix the failing Travis CI builds on Ruby versions 2.0.0 and 1.9.3