### PR TITLE
Lock ruby parser to 1.14.1 to ruby 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: ruby
 before_install:
   - gem update bundler
 rvm:
-- 1.9.3
-- 2.0.0
-- 2.1.7
 - 2.2.3
 - 2.3.0
 - 2.4.0

--- a/fasterer.gemspec
+++ b/fasterer.gemspec
@@ -18,12 +18,14 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '~> 2.2'
+
   spec.add_dependency 'colorize', '~> 0.7'
-  spec.add_dependency 'ruby_parser', '>= 3.13.0'
+  spec.add_dependency 'ruby_parser', '>= 3.14.1'
 
   spec.add_development_dependency 'bundler', '>= 1.6'
+  spec.add_development_dependency 'pry',     '~> 0.10'
   spec.add_development_dependency 'rake',    '~> 10.0'
   spec.add_development_dependency 'rspec',   '~> 3.2'
-  spec.add_development_dependency 'pry',     '~> 0.10'
   spec.add_development_dependency 'simplecov', '~> 0.9'
 end


### PR DESCRIPTION
Ruby parser dropped support for rubies below 2.2.0 so fasterer doing the same. If there will be people complaining, we will figure it out, as a lot of these ruby versions are not supported anymore.

Let's see how the build passes.