### PR TITLE
[Suggestion] Make output fully green if there are no offenses

### DIFF
--- a/lib/fasterer/file_traverser.rb
+++ b/lib/fasterer/file_traverser.rb
@@ -155,7 +155,7 @@ module Fasterer
     end
 
     def offenses_found_output
-      color = @offenses_found_count.zero? :green : :red
+      color = @offenses_found_count.zero? ? :green : :red
       "#{@offenses_found_count} #{pluralize(@offenses_found_count, 'offense')} detected"
         .colorize(color)
     end

--- a/lib/fasterer/file_traverser.rb
+++ b/lib/fasterer/file_traverser.rb
@@ -155,12 +155,14 @@ module Fasterer
     end
 
     def offenses_found_output
+      color = @offenses_found_count.zero? :green : :red
       "#{@offenses_found_count} #{pluralize(@offenses_found_count, 'offense')} detected"
-        .colorize(:red)
+        .colorize(color)
     end
 
     def unparsable_files_output
       return if @unparsable_files_count.zero?
+
       "#{@unparsable_files_count} unparsable #{pluralize(@unparsable_files_count, 'file')} found"
         .colorize(:red)
     end


### PR DESCRIPTION
Hi!
Not a big deal, but red color in output usually seems to be an alert of something, that went wrong. I think it will be prettier to show fully green message if there are no offenses found. Hope it fits well.