### PR TITLE
Replace colorize with rainbow

### DIFF
--- a/bin/fasterer
+++ b/bin/fasterer
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-$LOAD_PATH << File.expand_path('../../lib', __FILE__)
+$LOAD_PATH << File.expand_path('../lib', __dir__)
 require 'fasterer/cli'
 
 Fasterer::CLI.execute

--- a/fasterer.gemspec
+++ b/fasterer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.2'
 
-  spec.add_dependency 'colorize', '~> 0.7'
+  spec.add_dependency 'rainbow', '~> 3.0'
   spec.add_dependency 'ruby_parser', '>= 3.14.1'
 
   spec.add_development_dependency 'bundler', '>= 1.6'

--- a/lib/fasterer/file_traverser.rb
+++ b/lib/fasterer/file_traverser.rb
@@ -1,5 +1,5 @@
 require 'pathname'
-require 'colorize'
+require 'rainbow'
 require 'English'
 
 require_relative 'analyzer'
@@ -83,7 +83,8 @@ module Fasterer
       offenses_grouped_by_type(analyzer).each do |error_group_name, error_occurences|
         error_occurences.map(&:line_number).each do |line|
           file_and_line = "#{analyzer.file_path}:#{line}"
-          print "#{file_and_line.colorize(:red)} #{Fasterer::Offense::EXPLANATIONS[error_group_name]}.\n"
+          # print "#{Rainbow(file_and_line).color(:red)} #{Fasterer::Offense::EXPLANATIONS[error_group_name]}.\n"
+          print "#{Rainbow(file_and_line).color(:red)} #{Fasterer::Offense::EXPLANATIONS[error_group_name]}.\n"
         end
       end
 
@@ -112,7 +113,7 @@ module Fasterer
     end
 
     def output_unable_to_find_file(path)
-      puts "No such file or directory - #{path}".colorize(:red)
+      puts Rainbow("No such file or directory - #{path}").color(:red)
     end
 
     def ignored_speedups
@@ -150,21 +151,21 @@ module Fasterer
     end
 
     def inspected_files_output
-      "#{@files_inspected_count} #{pluralize(@files_inspected_count, 'file')} inspected"
-        .colorize(:green)
+      Rainbow("#{@files_inspected_count} #{pluralize(@files_inspected_count, 'file')} inspected")
+        .color(:green)
     end
 
     def offenses_found_output
       color = @offenses_found_count.zero? ? :green : :red
-      "#{@offenses_found_count} #{pluralize(@offenses_found_count, 'offense')} detected"
-        .colorize(color)
+      Rainbow("#{@offenses_found_count} #{pluralize(@offenses_found_count, 'offense')} detected")
+        .color(color)
     end
 
     def unparsable_files_output
       return if @unparsable_files_count.zero?
 
-      "#{@unparsable_files_count} unparsable #{pluralize(@unparsable_files_count, 'file')} found"
-        .colorize(:red)
+      Rainbow("#{@unparsable_files_count} unparsable #{pluralize(@unparsable_files_count, 'file')} found")
+        .color(:red)
     end
 
     def pluralize(n, singular, plural = nil)

--- a/lib/fasterer/file_traverser.rb
+++ b/lib/fasterer/file_traverser.rb
@@ -83,7 +83,6 @@ module Fasterer
       offenses_grouped_by_type(analyzer).each do |error_group_name, error_occurences|
         error_occurences.map(&:line_number).each do |line|
           file_and_line = "#{analyzer.file_path}:#{line}"
-          # print "#{Rainbow(file_and_line).color(:red)} #{Fasterer::Offense::EXPLANATIONS[error_group_name]}.\n"
           print "#{Rainbow(file_and_line).color(:red)} #{Fasterer::Offense::EXPLANATIONS[error_group_name]}.\n"
         end
       end

--- a/spec/lib/fasterer/file_traverser_spec.rb
+++ b/spec/lib/fasterer/file_traverser_spec.rb
@@ -348,7 +348,7 @@ describe Fasterer::FileTraverser do
       let(:explanation) { Fasterer::Offense::EXPLANATIONS[:for_loop_vs_each] }
 
       it 'should print offense' do
-        match = "\e[0;31;49m#{test_file_path}:1\e[0m #{explanation}.\n\n"
+        match = "\e[31m#{test_file_path}:1\e[0m #{explanation}.\n\n"
 
         expect { file_traverser.send(:output, analyzer) }.to output(match).to_stdout
       end


### PR DESCRIPTION
This change replaces `colorize` gem with `rainbow` gem.
That is because `fasterer` has MIT license, and `colorize` has GNU GPL license, hence `rainbow` with its MIT license seems a better fit.