### PR TITLE
Ruby 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
 - 2.5.0
 - 2.6.0
 - 2.7.0
+- 3.0.0
 env:
   global:
     secure: MBTxmpWCjrsNKPlOoFwJUMHze3GPMz8YCXQFQG3zJBh3WGNQnz4z91ra/1P/DClyVCxHGSFCOswxCNe4kJ2zAnPyQLqGSinXy9uDpqZQUEdaRoQbPnh4/bguZNSJ429gtTpMdDSNOgQ+Hra2EFnWwHA+rLF6ImksMsu3XGKGxGE=

--- a/fasterer.gemspec
+++ b/fasterer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '=> 2.2'
+  spec.required_ruby_version = '>= 2.2'
 
   spec.add_dependency 'colorize', '~> 0.7'
   spec.add_dependency 'ruby_parser', '>= 3.14.1'

--- a/fasterer.gemspec
+++ b/fasterer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.2'
+  spec.required_ruby_version = '=> 2.2'
 
   spec.add_dependency 'colorize', '~> 0.7'
   spec.add_dependency 'ruby_parser', '>= 3.14.1'

--- a/lib/fasterer/method_call.rb
+++ b/lib/fasterer/method_call.rb
@@ -29,7 +29,7 @@ module Fasterer
     end
 
     def arguments_element
-      call_element[3..-1] || []
+      call_element.sexp_body(3) || []
     end
 
     def lambda_literal?


### PR DESCRIPTION
closes https://github.com/DamirSvrtan/fasterer/issues/84

* relax Ruby requirements from `~> 2.2` to `=> 2.2` (which will allow upgrading to Ruby 3 --obviously^^)
* adds Ruby 3 to Travis config
* adjust syntax if necessary

The CI is failing since this commit: https://github.com/DamirSvrtan/fasterer/commit/aebf173d0b73cacdd2c812f7739da4157b304315 from Mar 2, 2020.

If you are OK, I suggest dropping support for 2.2 entirely, and set the required Ruby version to `=> 2.3`, since 2.3 is the oldest version that you can download from the official website. Also, Ruby 2.3 was released in 2015, 5 years ago.

<hr />

I've run RSpec locally against all Ruby versions that I have compiled on my machine:
✅   Ruby 2.3.8: `92 examples, 0 failures, 1 pending`
✅   Ruby 2.5.8: `92 examples, 0 failures, 1 pending`
✅   Ruby 2.6.6: `92 examples, 0 failures, 1 pending`
✅   Ruby 2.7.2: `92 examples, 0 failures, 1 pending`
✅   Ruby 3.0.0: `92 examples, 0 failures, 1 pending`
~❌   Ruby 3.0.0:~
```
Failures:

  1) Fasterer::Analyzer should detect gsub 4 times
     Failure/Error: expect(analyzer.errors[:gsub_vs_tr].count).to eq(2)
     
       expected: 2
            got: 1
     
       (compared using ==)
     # ./spec/lib/fasterer/analyzer/24_gsub_vs_tr_spec.rb:9:in `block (2 levels) in <top (required)>'

Finished in 2.04 seconds (files took 0.78213 seconds to load)
92 examples, 1 failure, 1 pending

Failed examples:

rspec ./spec/lib/fasterer/analyzer/24_gsub_vs_tr_spec.rb:6 # Fasterer::Analyzer should detect gsub 4 times
```

~=> should we:~
~* keep the current restriction ( 🙁  )~
~* wait for a fix~
~* fix Ruby 3 in this PR~
~* merge this, then fix Ruby 3 separately~

**update**: ✅    fixed. see comments below.

=> I've created a follow-up issue so that the failing specs can be addressed separately:
closes https://github.com/DamirSvrtan/fasterer/issues/86