### PR TITLE
Remove redundant instance variable from file traverser

### DIFF
--- a/lib/fasterer/file_traverser.rb
+++ b/lib/fasterer/file_traverser.rb
@@ -33,7 +33,7 @@ module Fasterer
     end
 
     def offenses_found?
-      !!offenses_found
+      !offenses_total_count.zero?
     end
 
     def scannable_files
@@ -41,8 +41,6 @@ module Fasterer
     end
 
     private
-
-    attr_accessor :offenses_found
 
     def traverse_files
       if @path.exist?
@@ -60,7 +58,6 @@ module Fasterer
     else
       if offenses_grouped_by_type(analyzer).any?
         output(analyzer)
-        self.offenses_found = true
         self.offenses_total_count += analyzer.errors.count
       end
     end


### PR DESCRIPTION
Hi! Found this thing: there is another variable to check if any offenses found, while there is another variable, which actually counts offences. Don't want to be mean to such approach, but I think removing that boolean variable and actually check if there was any errors in counter could do the trick too. Hope it fits well!