### PR TITLE
Hash#update() vs Hash#[]=

### DIFF
--- a/.fasterer.yml
+++ b/.fasterer.yml
@@ -12,6 +12,7 @@ speedups:
   fetch_with_argument_vs_block: true
   keys_each_vs_each_key: true
   hash_merge_bang_vs_hash_brackets: true
+  hash_update_vs_hash_brackets: true
   block_vs_symbol_to_proc: true
   proc_call_vs_yield: true
   gsub_vs_tr: true

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ speedups:
   fetch_with_argument_vs_block: true
   keys_each_vs_each_key: true
   hash_merge_bang_vs_hash_brackets: true
+  hash_update_vs_hash_brackets: true
   block_vs_symbol_to_proc: true
   proc_call_vs_yield: true
   gsub_vs_tr: true

--- a/lib/fasterer/offense.rb
+++ b/lib/fasterer/offense.rb
@@ -52,6 +52,9 @@ module Fasterer
       hash_merge_bang_vs_hash_brackets:
         'Hash#merge! with one argument is slower than Hash#[]',
 
+      hash_update_vs_hash_brackets:
+        'Hash#update with one argument is slower than Hash#[]',
+
       block_vs_symbol_to_proc:
         'Calling argumentless methods within blocks is slower than using symbol to proc',
 

--- a/lib/fasterer/scanners/method_call_scanner.rb
+++ b/lib/fasterer/scanners/method_call_scanner.rb
@@ -39,6 +39,8 @@ module Fasterer
         check_fetch_offense
       when :merge!
         check_merge_bang_offense
+      when :update
+        check_update_offense
       when :last
         check_last_offense
       when :include?
@@ -146,6 +148,17 @@ module Fasterer
 
       if first_argument.element.drop(1).count == 2 # each key and value is an item by itself.
         add_offense(:hash_merge_bang_vs_hash_brackets)
+      end
+    end
+
+    def check_update_offense
+      return unless method_call.arguments.count == 1
+
+      first_argument = method_call.arguments.first
+      return unless first_argument.type == :hash
+
+      if first_argument.element.drop(1).count == 2 # each key and value is an item by itself.
+        add_offense(:hash_update_vs_hash_brackets)
       end
     end
 

--- a/spec/lib/fasterer/analyzer/17_hash_update_vs_hash_brackets_spec.rb
+++ b/spec/lib/fasterer/analyzer/17_hash_update_vs_hash_brackets_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Fasterer::Analyzer do
+  let(:test_file_path) { RSpec.root.join('support', 'analyzer', '17_hash_update_vs_hash_brackets.rb') }
+
+  it 'should detect keys each 3 times' do
+    analyzer = Fasterer::Analyzer.new(test_file_path)
+    analyzer.scan
+    expect(analyzer.errors[:hash_update_vs_hash_brackets].count).to eq(3)
+  end
+end

--- a/spec/support/analyzer/17_hash_update_vs_hash_brackets.rb
+++ b/spec/support/analyzer/17_hash_update_vs_hash_brackets.rb
@@ -1,0 +1,21 @@
+h.update(item: 1, item2: 3)
+
+h.update
+
+h.update(item, item: 1)
+
+h.update(item: 1)
+
+ENUM.each_with_object({}) do |e, h|
+  h.update(e => e)
+end
+
+ENUM.each_with_object({}) do |e, h|
+  h[e] = e
+end
+
+h.update(item: 1)
+
+h.update({item: 1})
+
+h.update({})


### PR DESCRIPTION
Hash#update is an alias for Hash#merge!
Ergo, the suggestions for Hash#update should be similar to Hash#merge!

Ref https://github.com/DamirSvrtan/fasterer/issues/82

Link to Fast-Ruby PR : https://github.com/JuanitoFatas/fast-ruby/pull/195