### PR TITLE
Array#count vs Array#size

### DIFF
--- a/lib/fasterer/offense.rb
+++ b/lib/fasterer/offense.rb
@@ -71,7 +71,10 @@ module Fasterer
         'Use attr_writer for writing to ivars',
 
       include_vs_cover_on_range:
-        'Use #cover? instead of #include? on ranges'
+        'Use #cover? instead of #include? on ranges',
+
+      count_vs_size:
+        'Array#count with no arguments is slower than Array#size and Array#length'
     }
   end
 end

--- a/lib/fasterer/scanners/method_call_scanner.rb
+++ b/lib/fasterer/scanners/method_call_scanner.rb
@@ -31,6 +31,8 @@ module Fasterer
         check_each_with_index_offense
       when :first
         check_first_offense
+      when :count
+        check_count_offense
       when :each
         check_each_offense
       when :flatten
@@ -88,6 +90,12 @@ module Fasterer
         return unless method_call.receiver.has_block?
 
         add_offense(:select_first_vs_detect)
+      end
+    end
+
+    def check_count_offense
+      if method_call.arguments.count.zero? && !method_call.has_block?
+        add_offense(:count_vs_size)
       end
     end
 

--- a/spec/lib/fasterer/analyzer/30_count_vs_size_spec.rb
+++ b/spec/lib/fasterer/analyzer/30_count_vs_size_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Fasterer::Analyzer do
+  let(:test_file_path) { RSpec.root.join('support', 'analyzer', '30_count_vs_size.rb') }
+
+  it 'should count 3 times' do
+    analyzer = Fasterer::Analyzer.new(test_file_path)
+    analyzer.scan
+    expect(analyzer.errors[:count_vs_size].count).to eq(3)
+  end
+end

--- a/spec/support/analyzer/30_count_vs_size.rb
+++ b/spec/support/analyzer/30_count_vs_size.rb
@@ -1,0 +1,12 @@
+ARRAY = (0..100).to_a
+
+ARRAY.count
+
+ARRAY.map do |x|
+    x * 2
+end.count
+
+ARRAY.select { |x| x % 2 == 0 }.count
+
+ARRAY.count(2) # ok
+ARRAY.count(&:positive?) # ok


### PR DESCRIPTION
I added the offense `Array#count` vs `Array#size`/`Array#length`.

I'm aware that this will generate a lot of noise since `.count` is ActiveRecord method used very often. But keep in mind that this can be excluded with the configuration file or, in case of ActiveRecord, it can be replaced with `.size`, [which is often a better choice](http://web.archive.org/web/20100210204319/http://blog.hasmanythrough.com/2008/2/27/count-length-size).