### PR TITLE
[select-last-with-arguments]

### DIFF
--- a/lib/fasterer/scanners/method_call_scanner.rb
+++ b/lib/fasterer/scanners/method_call_scanner.rb
@@ -155,6 +155,8 @@ module Fasterer
 
       case method_call.receiver.name
       when :select
+        return if method_call.arguments.count > 0
+
         add_offense(:select_last_vs_reverse_detect)
       end
     end

--- a/spec/support/analyzer/25_select_last_vs_reverse_detect.rb
+++ b/spec/support/analyzer/25_select_last_vs_reverse_detect.rb
@@ -5,3 +5,5 @@ end
 def fast
   ARRAY.reverse.detect { |x| (x % 10).zero? }
 end
+
+ARRAY.select { |x| (x % 10).zero? }.last(5)


### PR DESCRIPTION
Don't add offense if .last is called with arguments in the same vein as .first change for 0.10.1

https://github.com/DamirSvrtan/fasterer/issues/99