### PR TITLE
Allow colorize 1.0 and greater

### DIFF
--- a/fasterer.gemspec
+++ b/fasterer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'colorize', '~> 0.7'
+  spec.add_dependency 'colorize', '> 0.7'
   spec.add_dependency 'ruby_parser', '>= 3.19.1'
 
   spec.add_development_dependency 'bundler', '>= 1.6'


### PR DESCRIPTION
There is a new major of colorize.

https://rubygems.org/gems/colorize/versions/1.1.0