### PR TITLE
Redis keys method should not trigger the each key recommendation

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.4.0','2.5.0','2.6.0','2.7.0','3.0.0','3.1.0','3.2.0']
+        ruby-version: ['2.5.0','2.6.0','2.7.0','3.0.0','3.1.0','3.2.0']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.3.0','2.4.0','2.5.0','2.6.0','2.7.0','3.0.0','3.1.0','3.2.0']
+        ruby-version: ['2.4.0','2.5.0','2.6.0','2.7.0','3.0.0','3.1.0','3.2.0']
 
     steps:
     - uses: actions/checkout@v3

--- a/lib/fasterer/scanners/method_call_scanner.rb
+++ b/lib/fasterer/scanners/method_call_scanner.rb
@@ -99,7 +99,9 @@ module Fasterer
       when :reverse
         add_offense(:reverse_each_vs_reverse_each)
       when :keys
-        add_offense(:keys_each_vs_each_key)
+        if method_call.receiver.arguments.count.zero?
+          add_offense(:keys_each_vs_each_key)
+        end
       end
     end
 

--- a/spec/support/analyzer/15_keys_each_vs_each_key.rb
+++ b/spec/support/analyzer/15_keys_each_vs_each_key.rb
@@ -13,3 +13,7 @@ HASH.keys.each do |key|
 end
 
 HASH.each_key(&:to_sym)
+
+@redis.keys('queue:*').each do |queue_name|
+  puts queue_name
+end


### PR DESCRIPTION
This is a fix for #102.

It's not the ideal solution, but there's only so much one can do with static analysis in dynamically typed languages like Ruby. 