### PR TITLE
Replace colorize with a simple internal implementation

### DIFF
--- a/fasterer.gemspec
+++ b/fasterer.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'colorize', '~> 0.7'
   spec.add_dependency 'ruby_parser', '>= 3.19.1'
 
   spec.add_development_dependency 'bundler', '>= 1.6'

--- a/lib/fasterer/file_traverser.rb
+++ b/lib/fasterer/file_traverser.rb
@@ -1,9 +1,9 @@
 require 'pathname'
-require 'colorize'
 require 'English'
 
 require_relative 'analyzer'
 require_relative 'config'
+require_relative 'painter'
 
 module Fasterer
   class FileTraverser
@@ -83,7 +83,7 @@ module Fasterer
       offenses_grouped_by_type(analyzer).each do |error_group_name, error_occurences|
         error_occurences.map(&:line_number).each do |line|
           file_and_line = "#{analyzer.file_path}:#{line}"
-          print "#{file_and_line.colorize(:red)} #{Fasterer::Offense::EXPLANATIONS[error_group_name]}.\n"
+          print "#{Painter.paint(file_and_line, :red)} #{Fasterer::Offense::EXPLANATIONS[error_group_name]}.\n"
         end
       end
 
@@ -112,7 +112,7 @@ module Fasterer
     end
 
     def output_unable_to_find_file(path)
-      puts "No such file or directory - #{path}".colorize(:red)
+      puts Painter.paint("No such file or directory - #{path}", :red)
     end
 
     def ignored_speedups
@@ -150,21 +150,19 @@ module Fasterer
     end
 
     def inspected_files_output
-      "#{@files_inspected_count} #{pluralize(@files_inspected_count, 'file')} inspected"
-        .colorize(:green)
+      Painter.paint("#{@files_inspected_count} #{pluralize(@files_inspected_count, 'file')} inspected", :green)
     end
 
     def offenses_found_output
       color = @offenses_found_count.zero? ? :green : :red
-      "#{@offenses_found_count} #{pluralize(@offenses_found_count, 'offense')} detected"
-        .colorize(color)
+
+      Painter.paint("#{@offenses_found_count} #{pluralize(@offenses_found_count, 'offense')} detected", color)
     end
 
     def unparsable_files_output
       return if @unparsable_files_count.zero?
 
-      "#{@unparsable_files_count} unparsable #{pluralize(@unparsable_files_count, 'file')} found"
-        .colorize(:red)
+      Painter.paint("#{@unparsable_files_count} unparsable #{pluralize(@unparsable_files_count, 'file')} found", :red)
     end
 
     def pluralize(n, singular, plural = nil)

--- a/lib/fasterer/painter.rb
+++ b/lib/fasterer/painter.rb
@@ -1,0 +1,20 @@
+module Fasterer
+  module Painter
+    COLOR_CODES = {
+      red: 31,
+      green: 32,
+    }
+
+    def self.paint(string, color)
+      color_code = COLOR_CODES[color.to_sym]
+      if color_code.nil?
+        raise ArgumentError, "Color #{color} is not supported. Allowed colors are #{COLOR_CODES.keys.join(', ')}"
+      end
+      paint_with_code(string, color_code)
+    end
+
+    def self.paint_with_code(string, color_code)
+      "\e[#{color_code}m#{string}\e[0m"
+    end
+  end
+end

--- a/spec/lib/fasterer/file_traverser_spec.rb
+++ b/spec/lib/fasterer/file_traverser_spec.rb
@@ -348,7 +348,7 @@ describe Fasterer::FileTraverser do
       let(:explanation) { Fasterer::Offense::EXPLANATIONS[:for_loop_vs_each] }
 
       it 'should print offense' do
-        match = "\e[0;31;49m#{test_file_path}:1\e[0m #{explanation}.\n\n"
+        match = "\e[31m#{test_file_path}:1\e[0m #{explanation}.\n\n"
 
         expect { file_traverser.send(:output, analyzer) }.to output(match).to_stdout
       end

--- a/spec/lib/fasterer/statistics_spec.rb
+++ b/spec/lib/fasterer/statistics_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Fasterer::Statistics do
+  let(:traverser_mock) do
+    traverser = OpenStruct.new
+    traverser.scannable_files = []
+    traverser.offenses_total_count = 0
+    traverser.parse_error_paths = []
+    traverser
+  end
+
+  let(:statistics) { Fasterer::Statistics.new(traverser_mock) }
+
+  describe 'inspected_files_output' do
+    it 'should be green' do
+      expect(statistics.inspected_files_output)
+        .to eq("\e[32m0 files inspected\e[0m")
+    end
+  end
+end


### PR DESCRIPTION
Fasterer has been using the colorize gem for coloring output since it's inception, and to my surprise, more issues were opened related to it then i would expect. Given it's a simple implementation and we use a very small subset of features (color in red, color in green), here's an attempt to replace it with an internal implementation.

I would not be surprised if there is a bug or two that pops up for folks, but that's okay, we'll solve it and get rid of colorize.