### PR TITLE
Offenses should print the rule name

### DIFF
--- a/lib/fasterer/offense.rb
+++ b/lib/fasterer/offense.rb
@@ -12,7 +12,7 @@ module Fasterer
     end
 
     def explanation
-      @explanation ||= EXPLANATIONS.fetch(offense_name)
+      @explanation ||= "#{offense_name}: #{EXPLANATIONS.fetch(offense_name)}
     end
 
     EXPLANATIONS = {


### PR DESCRIPTION
Other linters give you which rule is offending. Examples:

Rubocop: `Style/StringLiterals`
![image](https://github.com/DamirSvrtan/fasterer/assets/48229166/497a137c-e4c1-40e1-b37d-a57ffd0446a6)

ESLint: `semi`
![image](https://github.com/DamirSvrtan/fasterer/assets/48229166/b1dca4b2-47e8-4f77-b31f-d6104d417edd)

Fasterer should too :)

This is slightly confusing and unhelpful:
![image](https://github.com/DamirSvrtan/fasterer/assets/48229166/67ba6b11-a5ff-497b-a78b-f592b8c8c741)

I shouldn't have to come to this repo's README and check, and find it, whenever I need to disable a rule 🙏 

--

This is related to (and conflicts with) https://github.com/DamirSvrtan/fasterer/pull/78 , but that PR is from 2020. Maybe this one-liner would be merge first 🤷 