### PR TITLE
Add Ruby 4.0 support and drop EOL Ruby versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.5.0','2.6.0','2.7.0','3.0.0','3.1.0','3.2.0']
+        ruby-version: ['3.2', '3.3', '3.4', '4.0']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.12.0
+
+- Add explicit support for Ruby 4.0
+- Drop support for EOL Ruby versions (2.x, 3.0, 3.1). The minimum required Ruby version is now 3.2.
+
 ## 0.11.0
 
 - There have been multiple issues filed with the colorize gem, such as licencing, gem versions etc. Due to the easy implementation, fasterer will now leverage an internal implementation of this so we don't need to get issues tracked bc of colorize. There might be other issues that arise (perhaps somebody leveraging Windows might have issues), but that's okay, we'll solve it.

--- a/fasterer.gemspec
+++ b/fasterer.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ruby_parser', '>= 3.22.0'
 
   spec.add_development_dependency 'bundler', '>= 1.6'
-  spec.add_development_dependency 'ostruct', '>= 0.6'
   spec.add_development_dependency 'pry',     '~> 0.10'
   spec.add_development_dependency 'rake',    '>= 12.3.3'
   spec.add_development_dependency 'rspec',   '~> 3.2'

--- a/fasterer.gemspec
+++ b/fasterer.gemspec
@@ -18,11 +18,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 3.2'
 
-  spec.add_dependency 'ruby_parser', '>= 3.19.1'
+  spec.add_dependency 'ruby_parser', '>= 3.22.0'
 
   spec.add_development_dependency 'bundler', '>= 1.6'
+  spec.add_development_dependency 'ostruct', '>= 0.6'
   spec.add_development_dependency 'pry',     '~> 0.10'
   spec.add_development_dependency 'rake',    '>= 12.3.3'
   spec.add_development_dependency 'rspec',   '~> 3.2'

--- a/lib/fasterer.rb
+++ b/lib/fasterer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fasterer/version'
 require 'fasterer/analyzer'
 require 'fasterer/method_definition'

--- a/lib/fasterer/analyzer.rb
+++ b/lib/fasterer/analyzer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fasterer/method_definition'
 require 'fasterer/method_call'
 require 'fasterer/rescue_call'

--- a/lib/fasterer/cli.rb
+++ b/lib/fasterer/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'file_traverser'
 
 module Fasterer

--- a/lib/fasterer/config.rb
+++ b/lib/fasterer/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yaml'
 require 'pathname'
 

--- a/lib/fasterer/file_traverser.rb
+++ b/lib/fasterer/file_traverser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'English'
 

--- a/lib/fasterer/method_call.rb
+++ b/lib/fasterer/method_call.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fasterer
   class MethodCall
     attr_reader :element

--- a/lib/fasterer/method_definition.rb
+++ b/lib/fasterer/method_definition.rb
@@ -43,12 +43,12 @@ module Fasterer
     end
 
     def set_body
-      @body = @element[3..-1]
+      @body = @element[3..]
     end
 
     def set_block_argument_name
       if last_argument_element.to_s.start_with?('&')
-        @block_argument_name = last_argument_element.to_s[1..-1].to_sym
+        @block_argument_name = last_argument_element.to_s.delete_prefix('&').to_sym
       end
     end
 

--- a/lib/fasterer/method_definition.rb
+++ b/lib/fasterer/method_definition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fasterer
   class MethodDefinition
     attr_reader :element # for testing purposes

--- a/lib/fasterer/offense.rb
+++ b/lib/fasterer/offense.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fasterer
   class Offense
     attr_reader :offense_name, :line_number

--- a/lib/fasterer/offense_collector.rb
+++ b/lib/fasterer/offense_collector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 
 module Fasterer

--- a/lib/fasterer/painter.rb
+++ b/lib/fasterer/painter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fasterer
   module Painter
     COLOR_CODES = {

--- a/lib/fasterer/parser.rb
+++ b/lib/fasterer/parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ruby_parser'
 
 module Fasterer

--- a/lib/fasterer/rescue_call.rb
+++ b/lib/fasterer/rescue_call.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fasterer
   class RescueCall
     attr_reader :element

--- a/lib/fasterer/rescue_call.rb
+++ b/lib/fasterer/rescue_call.rb
@@ -16,9 +16,9 @@ module Fasterer
     def set_rescue_classes
       return if element[1].sexp_type != :array
 
-      @rescue_classes = element[1].drop(1).map do |rescue_reference|
+      @rescue_classes = element[1].drop(1).filter_map do |rescue_reference|
         rescue_reference[1] if rescue_reference.sexp_type == :const
-      end.compact
+      end
     end
   end
 end

--- a/lib/fasterer/scanners/method_call_scanner.rb
+++ b/lib/fasterer/scanners/method_call_scanner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fasterer/method_call'
 require 'fasterer/offense'
 require 'fasterer/scanners/offensive'

--- a/lib/fasterer/scanners/method_definition_scanner.rb
+++ b/lib/fasterer/scanners/method_definition_scanner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fasterer/method_definition'
 require 'fasterer/method_call'
 require 'fasterer/offense'

--- a/lib/fasterer/scanners/method_definition_scanner.rb
+++ b/lib/fasterer/scanners/method_definition_scanner.rb
@@ -65,7 +65,7 @@ module Fasterer
       return if first_argument.type != :regular_argument
 
       if method_definition.body.first.sexp_type == :iasgn &&
-         method_definition.body.first[1].to_s == "@#{method_definition.name.to_s[0..-2]}" &&
+         method_definition.body.first[1].to_s == "@#{method_definition.name.to_s.delete_suffix('=')}" &&
          method_definition.body.first[2][1] == first_argument.name
 
         add_offense(:setter_vs_attr_writer)

--- a/lib/fasterer/scanners/offensive.rb
+++ b/lib/fasterer/scanners/offensive.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fasterer/offense'
 
 module Fasterer

--- a/lib/fasterer/scanners/rescue_call_scanner.rb
+++ b/lib/fasterer/scanners/rescue_call_scanner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fasterer/rescue_call'
 require 'fasterer/offense'
 require 'fasterer/scanners/offensive'

--- a/lib/fasterer/token.rb
+++ b/lib/fasterer/token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fasterer
   class Token
     def initialize(name)

--- a/lib/fasterer/version.rb
+++ b/lib/fasterer/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fasterer
   VERSION = '0.11.0'
 end

--- a/spec/lib/fasterer/statistics_spec.rb
+++ b/spec/lib/fasterer/statistics_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'ostruct'
 
 describe Fasterer::Statistics do
   let(:traverser_mock) do

--- a/spec/lib/fasterer/statistics_spec.rb
+++ b/spec/lib/fasterer/statistics_spec.rb
@@ -1,13 +1,9 @@
 require 'spec_helper'
-require 'ostruct'
 
 describe Fasterer::Statistics do
   let(:traverser_mock) do
-    traverser = OpenStruct.new
-    traverser.scannable_files = []
-    traverser.offenses_total_count = 0
-    traverser.parse_error_paths = []
-    traverser
+    Struct.new(:scannable_files, :offenses_total_count, :parse_error_paths)
+      .new([], 0, [])
   end
 
   let(:statistics) { Fasterer::Statistics.new(traverser_mock) }


### PR DESCRIPTION
## Summary

- Raise `required_ruby_version` from `>= 2.3` to `>= 3.2`, dropping all EOL Ruby versions (2.x, 3.0, 3.1)
- Bump `ruby_parser` dependency from `>= 3.19.1` to `>= 3.22.0` for latest Ruby syntax support
- Update CI matrix to test against Ruby 3.2, 3.3, 3.4, and 4.0
- Update `actions/checkout` from v3 to v4 (v3 uses Node 16, which is EOL)
- Add `frozen_string_literal: true` to all 18 lib files to reduce string allocations
- Use `filter_map` instead of `map { ... }.compact` in `rescue_call.rb`
- Replace positional string slicing (`[1..-1]`, `[0..-2]`, `[3..-1]`) with `delete_prefix`, `delete_suffix`, and endless ranges for clarity
- Replace `OpenStruct` with `Struct` in `statistics_spec` and remove `ostruct` development dependency

## Motivation

Ruby 2.x, 3.0, and 3.1 have all reached [end-of-life](https://endoflife.date/ruby) and no longer receive security patches. Meanwhile, `ruby_parser` 3.22.0 already requires Ruby >= 3.2, so `fasterer`'s gemspec was out of sync — users on older Rubies couldn't successfully install the dependency chain anyway.

Ruby 4.0 was released on December 25, 2025, and this PR adds it to the CI matrix so that compatibility is tested explicitly.

### EOL dates for dropped versions

| Version | EOL Date |
|---------|----------|
| Ruby 3.1 | March 31, 2025 |
| Ruby 3.0 | April 23, 2024 |
| Ruby 2.7 | March 31, 2023 |
| Ruby 2.6 | March 31, 2022 |
| Ruby 2.5 | March 31, 2021 |

### Modernize lib/ for Ruby 3.2+

With the minimum Ruby version raised to 3.2, the lib/ source code can now use idiomatic patterns from newer Ruby versions:

- **`frozen_string_literal: true`** — No string mutations (`<<`, `gsub!`, `sub!`, etc.) exist in lib/, so this is safe across all 18 files. Reduces string allocations and GC pressure.
- **`filter_map`** (Ruby 2.7+) — Combines `map` and `compact` into a single pass, avoiding an intermediate array allocation.
- **`delete_prefix` / `delete_suffix`** (Ruby 2.5+) — Replaces positional string slicing like `[1..-1]` and `[0..-2]` with intent-revealing methods that describe *what* is being removed rather than *where* to slice.
- **Endless ranges** (Ruby 2.6+) — `[3..]` instead of `[3..-1]`, dropping the redundant `-1` sentinel.

### Replace `OpenStruct` with `Struct`

`OpenStruct` is no longer auto-loaded in Ruby 3.4+ and will be removed from default gems in Ruby 4.0. Since the spec only needs a simple data object with three known attributes, `Struct` is a better fit — it's always available in core Ruby and doesn't carry `OpenStruct`'s `method_missing` overhead. This also removes the `ostruct` development dependency from the gemspec.

## Note on `ruby_parser` EOL

It's worth noting that [`ruby_parser` itself is now EOL](https://github.com/seattlerb/ruby_parser?tab=readme-ov-file#notice). The maintainer recommends migrating to [Prism](https://github.com/ruby/prism) (`~> 1.7`), which ships with Ruby 3.3+ and offers a `ruby_parser` compatibility mode that produces S-expressions in the same format.

This PR keeps `ruby_parser` for now as a minimal, non-breaking change. The migration to Prism has already been started in #111.

## Test plan

- [ ] CI passes for Ruby 3.2, 3.3, 3.4, and 4.0
- [x] `gem build fasterer.gemspec` succeeds
- [x] `bundle install` resolves `ruby_parser >= 3.22.0` correctly
- [x] Full test suite passes (93 examples, 0 failures)